### PR TITLE
Validaciones en el formulario para la creación y edición de usuarios

### DIFF
--- a/src/components/AdminComponents/ModalCrear.jsx
+++ b/src/components/AdminComponents/ModalCrear.jsx
@@ -102,6 +102,20 @@ const ModalCrear = () => {
                       placeholder="Ingresar apellido"
                       {...register("apellido", {
                         required: "El apellido es obligatorio",
+                        minLength: {
+                          value: 3,
+                          message:
+                            "Ingrese un apellido con un mínimo de 3 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "El apellido no puede tener más de 50 caracteres",
+                        },
+                        pattern: {
+                          value: /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/i,
+                          message: "El apellido solo puede contener letras",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -115,6 +129,20 @@ const ModalCrear = () => {
                       placeholder="Ingresar nombre"
                       {...register("nombre", {
                         required: "El nombre es obligatorio",
+                        minLength: {
+                          value: 3,
+                          message:
+                            "Ingrese un nombre con un mínimo de 3 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "El nombre no puede tener más de 50 caracteres",
+                        },
+                        pattern: {
+                          value: /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/i,
+                          message: "El nombre solo puede contener letras",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -124,10 +152,18 @@ const ModalCrear = () => {
                   <Form.Group className="mb-3" controlId="formDNI">
                     <Form.Label>DNI</Form.Label>
                     <Form.Control
-                      type="text"
+                      type="number"
                       placeholder="Ingresar DNI"
                       {...register("dni", {
                         required: "El DNI es obligatorio",
+                        min: {
+                          value: 10000000,
+                          message: "Ingrese un dni valido",
+                        },
+                        max: {
+                          value: 99999999,
+                          message: "Ingrese un dni valido",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -141,6 +177,11 @@ const ModalCrear = () => {
                       placeholder="3865123456"
                       {...register("telefono", {
                         required: "El teléfono es obligatorio",
+                        pattern: {
+                          value: /^\d{10,15}$/,
+                          message:
+                            "El teléfono debe tener entre 10 y 15 dígitos",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -156,6 +197,16 @@ const ModalCrear = () => {
                       placeholder="Calle 123"
                       {...register("direccion", {
                         required: "La dirección es obligatoria",
+                        minLength: {
+                          value: 5,
+                          message:
+                            "Ingrese una dirección con un mínimo de 5 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "La dirección no puede tener más de 50 caracteres",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -169,6 +220,10 @@ const ModalCrear = () => {
                       placeholder="ejemplo@gmail.com"
                       {...register("email", {
                         required: "El email es obligatorio",
+                        pattern: {
+                          value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/i,
+                          message: "Debe ingresar un email válido",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -182,6 +237,16 @@ const ModalCrear = () => {
                       placeholder="Ingresar contraseña"
                       {...register("password", {
                         required: "Contraseña obligatoria",
+                        minLength: {
+                          value: 6,
+                          message:
+                            "La contraseña debe tener al menos 6 caracteres",
+                        },
+                        pattern: {
+                          value: /^(?=.*[A-Z])(?=.*[!@#$%^&*])/,
+                          message:
+                            "La contraseña debe tener al menos una letra mayúscula y un carácter especial",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -204,7 +269,7 @@ const ModalCrear = () => {
                     </Form.Text>
                   </Form.Group>
                   <Form.Group className="mb-3" controlId="formImagen">
-                    <Form.Label>Imagen</Form.Label>
+                    <Form.Label>URL de la imagen</Form.Label>
                     <Form.Control
                       type="text"
                       placeholder="Ingresar la URL de la imagen"

--- a/src/components/AdminComponents/ModalEditar.jsx
+++ b/src/components/AdminComponents/ModalEditar.jsx
@@ -113,6 +113,20 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="Ingresar apellido"
                       {...register("apellido", {
                         required: "El apellido es obligatorio",
+                        minLength: {
+                          value: 3,
+                          message:
+                            "Ingrese un apellido con un mínimo de 3 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "El apellido no puede tener más de 50 caracteres",
+                        },
+                        pattern: {
+                          value: /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/i,
+                          message: "El apellido solo puede contener letras",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -126,6 +140,20 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="Ingresar nombre"
                       {...register("nombre", {
                         required: "El nombre es obligatorio",
+                        minLength: {
+                          value: 3,
+                          message:
+                            "Ingrese un nombre con un mínimo de 3 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "El nombre no puede tener más de 50 caracteres",
+                        },
+                        pattern: {
+                          value: /^[A-Za-zÁÉÍÓÚáéíóúñÑ ]+$/i,
+                          message: "El nombre solo puede contener letras",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -135,10 +163,18 @@ const ModalEditar = ({ usuario }) => {
                   <Form.Group className="mb-3" controlId="formDNI">
                     <Form.Label>DNI</Form.Label>
                     <Form.Control
-                      type="text"
+                      type="number"
                       placeholder="Ingresar DNI"
                       {...register("dni", {
                         required: "El DNI es obligatorio",
+                        min: {
+                          value: 10000000,
+                          message: "Ingrese un dni valido",
+                        },
+                        max: {
+                          value: 99999999,
+                          message: "Ingrese un dni valido",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -152,6 +188,11 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="3865123456"
                       {...register("telefono", {
                         required: "El teléfono es obligatorio",
+                        pattern: {
+                          value: /^\d{10,15}$/,
+                          message:
+                            "El teléfono debe tener entre 10 y 15 dígitos",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -167,6 +208,16 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="Calle 123"
                       {...register("direccion", {
                         required: "La dirección es obligatoria",
+                        minLength: {
+                          value: 5,
+                          message:
+                            "Ingrese una dirección con un mínimo de 5 caracteres",
+                        },
+                        maxLength: {
+                          value: 50,
+                          message:
+                            "La dirección no puede tener más de 50 caracteres",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -180,6 +231,10 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="ejemplo@gmail.com"
                       {...register("email", {
                         required: "El email es obligatorio",
+                        pattern: {
+                          value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/i,
+                          message: "Debe ingresar un email válido",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">
@@ -193,6 +248,16 @@ const ModalEditar = ({ usuario }) => {
                       placeholder="Ingresar contraseña"
                       {...register("password", {
                         required: "Contraseña obligatoria",
+                        minLength: {
+                          value: 6,
+                          message:
+                            "La contraseña debe tener al menos 6 caracteres",
+                        },
+                        pattern: {
+                          value: /^(?=.*[A-Z])(?=.*[!@#$%^&*])/,
+                          message:
+                            "La contraseña debe tener al menos una letra mayúscula y un carácter especial",
+                        },
                       })}
                     />
                     <Form.Text className="text-danger">


### PR DESCRIPTION
Agregué las validaciones que faltaban al crear o editar usuarios:
Apellido: 3 char mínimo, 50 max, solamente letras
Nombre: 3 char mínimo, 50 max, solamente letras
DNI: número entre 10000000 y 99999999
Tel: número de 10 a 15 char
Dirección: mínimo de 5 char y max de 50
Email: exp regular  /^[^\s@]+@[^\s@]+\.[^\s@]+$/i
Contraseña: mínimo de 6 char y que tenga al menos una letra en mayúsculas y un char especial
Confirmar contraseña: que coincida con la contraseña original
URL de la imagen: exp reg /^(https?:\/\/.*\.(?:png|jpg|jpeg|gif|bmp))$/i